### PR TITLE
Adding `homepage` and repo values to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "name": "Jon Schlinkert",
     "url": "https://github.com/jonschlinkert"
   },
+  "homepage": "https://github.com/jonschlinkert/normalize-pkg/",
   "bugs": {
     "url": "https://github.com/jonschlinkert/normalize-pkg/issues"
   },
@@ -40,7 +41,7 @@
     "chai": "~1.9.1"
   },
   "repository": {
-    "type": "",
-    "url": ""
+    "type": "git",
+    "url": "git@github.com:jonschlinkert/normalize-pkg.git"
   }
 }


### PR DESCRIPTION
Note, still doesn't pass http://package-json-validator.com/ validator:

``` json
{
  "valid": false,
  "errors": [
    "Type for field license, was expected to be string, not object"
  ],
  "warnings": [
    "Missing recommended field: contributors"
  ]
}
```

The solution to that is to use `licenses` and wrap it in an array:

``` json
  "licenses": [{
    "type": "MIT",
    "url": "https://github.com/jonschlinkert/normalize-pkg/blob/master/LICENSE-MIT"
  }],
```
